### PR TITLE
Use the system palette to determine the default text color for log messages

### DIFF
--- a/src/views/console.cc
+++ b/src/views/console.cc
@@ -14,6 +14,7 @@
  * *****************************************************************************
  */
 
+#include <QPalette>
 #include "lib/logger.h"
 #include "views/console.h"
 
@@ -71,9 +72,11 @@ Console::LogPrivate(int level, const QString& msg)
 	case DEBUG:
 		color = QColor("Blue");
 		break;
-	case INFO:
-		color = QColor("Black");
+	case INFO: {
+		QPalette palette;
+		color = palette.color(QPalette::Text);
 		break;
+	}
 	case WARNING:
 		color = QColor(175, 175, 0);
 		break;


### PR DESCRIPTION
Use the system palette to determine the default text color for log messages. This is a fix for dark themes (tested on KDE with Obsidian Coast theme).
