### PR TITLE
Added a new function that logs only to the log file, used for bulk…

### DIFF
--- a/src/lib/client.cc
+++ b/src/lib/client.cc
@@ -764,14 +764,14 @@ Client::ProcessJobChunk(BulkWorkItem* workItem)
 					Client::GetObject(bucketName, objName,
 							  filePath, offset,
 							  static_cast<BulkGetWorkItem*>(workItem));
-					LOG_INFO("     GET     OBJECT    "+"/"+bucketName+"/"+objName+"->"+filePath);
+					LOG_FILE(QString("     GET     OBJECT    ")+"/"+bucketName+"/"+objName+"->"+filePath);
 				} else {
 					uint64_t length = bulkObj->length;
 					Client::PutObject(bucketName, objName,
 							  filePath, offset,
 							  length,
 							  static_cast<BulkPutWorkItem*>(workItem));
-					LOG_INFO("     PUT     OBJECT    "+filePath+"->"+"/"+bucketName+"/"+objName);
+					LOG_FILE(QString("     PUT     OBJECT    ")+filePath+"->"+"/"+bucketName+"/"+objName);
 				}
 			}
 			catch (DS3Error& e) {

--- a/src/lib/logger.h
+++ b/src/lib/logger.h
@@ -22,7 +22,8 @@
 #define LOG_DEBUG(msg)   LOG(Console::DEBUG,   msg)
 #define LOG_INFO(msg)    LOG(Console::INFO,    msg)
 #define LOG_WARNING(msg) LOG(Console::WARNING, msg)
-#define LOG_ERROR(msg)   LOG(Console::ERR,   msg)
+#define LOG_ERROR(msg)   LOG(Console::ERR,     msg)
+#define LOG_FILE(msg)    LOG(Console::FILE,    msg)
 #define LOG(level, msg)  Console::Instance()->Log(level, msg)
 
 #endif

--- a/src/views/console.cc
+++ b/src/views/console.cc
@@ -75,6 +75,7 @@ Console::Log(Level level, const QString& msg)
 void
 Console::LogPrivate(int level, const QString& msg)
 {
+	bool fileOnly = false;
 	bool fileLogging = true;
 	QString color;
 	switch (level) {
@@ -88,10 +89,13 @@ Console::LogPrivate(int level, const QString& msg)
 	case ERR:
 		color = "red";
 		break;
+	case FILE:
+		fileOnly = true;
+		break;
 	};
 
 	m_lock.lock();
-	if(!msg.startsWith("     ")) {
+	if(!fileOnly) {
 		if (m_numLines >= MAX_LINES) {
 			m_text->moveCursor(QTextCursor::Start,
 					   QTextCursor::MoveAnchor);

--- a/src/views/console.h
+++ b/src/views/console.h
@@ -32,7 +32,7 @@ class Console : public QWidget
 	Q_OBJECT
 
 public:
-	enum Level { DEBUG, INFO, WARNING, ERR };
+	enum Level { DEBUG, INFO, WARNING, ERR, FILE };
 	static const unsigned int MAX_LINES;
 
 	static Console* Instance();


### PR DESCRIPTION
…jobs so that every object in the bulk job doesn't fill up the console.
